### PR TITLE
Stringfuzzx: multiply and translate should not modify literals in re.range (unless asked to).

### DIFF
--- a/bin/stringfuzzx
+++ b/bin/stringfuzzx
@@ -35,10 +35,11 @@ TRANSFORMERS = {
 }
 
 # defaults
-DEFAULT_SEED         = 0
-DEFAULT_RANDOM       = False
-DEFAULT_FACTOR       = 2
-DEFAULT_INTEGER_FLAG = False
+DEFAULT_SEED          = 0
+DEFAULT_RANDOM        = False
+DEFAULT_FACTOR        = 2
+DEFAULT_INTEGER_FLAG  = False
+DEFAULT_RE_RANGE_FLAG = False
 
 def main():
 
@@ -111,7 +112,14 @@ def main():
         default = DEFAULT_FACTOR,
         help    = 'number to multiply literals by (default: {})'.format(DEFAULT_FACTOR)
     )
-
+    multiply_parser.add_argument(
+        '--re-range',
+        dest    = 're_range_flag',
+        action  = 'store_true',
+        default = DEFAULT_RE_RANGE_FLAG,
+        help    = 'Include re_range nodes in multiplication (default: {})'.format(DEFAULT_RE_RANGE_FLAG)
+    )
+    
     # nop transformer
     nop_parser = subparsers.add_parser(NOP, help='nop transformer')
 
@@ -130,7 +138,14 @@ def main():
         default = DEFAULT_INTEGER_FLAG,
         help    = 'Include integers in translation (default: {})'.format(DEFAULT_INTEGER_FLAG)
     )
-    
+    translate_parser.add_argument(
+        '--re-range',
+        dest    = 're_range_flag',
+        action  = 'store_true',
+        default = DEFAULT_RE_RANGE_FLAG,
+        help    = 'Include re_range nodes in translation (default: {})'.format(DEFAULT_RE_RANGE_FLAG)
+    )
+
     # unprintable transformer
     unprintable_parser = subparsers.add_parser(UNPRINTABLE, help='unprintable transformer')
 

--- a/stringfuzz/analyser.py
+++ b/stringfuzz/analyser.py
@@ -60,7 +60,7 @@ class StatsWalker(ASTWalker):
         assert len(self.nesting_stack) > 0
         return self.nesting_stack[-1]
 
-    def enter_expression(self, expression):
+    def enter_expression(self, expression, parent):
 
         # push nesting if we're at least one expression deep
         if self.depth > 1:
@@ -87,7 +87,7 @@ class StatsWalker(ASTWalker):
         # increase depth
         self.depth += 1
 
-    def exit_expression(self, expression):
+    def exit_expression(self, expression, parent):
 
         # decrease depth
         self.depth -= 1
@@ -97,11 +97,11 @@ class StatsWalker(ASTWalker):
         self.expr_stack.pop()
         self.nesting_stack.pop()
 
-    def enter_literal(self, literal):
+    def enter_literal(self, literal, parent):
         assert self.point is not None
         self.literals.append(literal)
 
-    def enter_identifier(self, variable):
+    def enter_identifier(self, variable, parent):
         assert self.point is not None
         self.variables.add(variable.name)
 

--- a/stringfuzz/ast_walker.py
+++ b/stringfuzz/ast_walker.py
@@ -13,51 +13,51 @@ class ASTWalker(object):
     # public API
     def walk(self):
         for expression in self.__ast:
-            self.walk_expression(expression)
+            self.walk_expression(expression, None)
 
         return self.__ast
 
     # walks
-    def walk_expression(self, expression):
+    def walk_expression(self, expression, parent):
 
-        self.enter_expression(expression)
+        self.enter_expression(expression, parent)
 
         for sub_expression in expression.body:
             if isinstance(sub_expression, ExpressionNode):
-                self.walk_expression(sub_expression)
+                self.walk_expression(sub_expression, expression)
 
             if isinstance(sub_expression, IdentifierNode):
-                self.walk_identifier(sub_expression)
+                self.walk_identifier(sub_expression, expression)
 
             if isinstance(sub_expression, LiteralNode):
-                self.walk_literal(sub_expression)
+                self.walk_literal(sub_expression, expression)
 
-        self.exit_expression(expression)
+        self.exit_expression(expression, parent)
 
-    def walk_literal(self, literal):
-        self.enter_literal(literal)
-        self.exit_literal(literal)
+    def walk_literal(self, literal, parent):
+        self.enter_literal(literal, parent)
+        self.exit_literal(literal, parent)
 
-    def walk_identifier(self, identifier):
-        self.enter_identifier(identifier)
-        self.exit_identifier(identifier)
+    def walk_identifier(self, identifier, parent):
+        self.enter_identifier(identifier, parent)
+        self.exit_identifier(identifier, parent)
 
     # enters/exits
-    def enter_expression(self, expression):
+    def enter_expression(self, expression, parent):
         pass
 
-    def exit_expression(self, expression):
+    def exit_expression(self, expression, parent):
         pass
 
-    def enter_literal(self, literal):
+    def enter_literal(self, literal, parent):
         pass
 
-    def exit_literal(self, literal):
+    def exit_literal(self, literal, parent):
         pass
 
-    def enter_identifier(self, identifier):
+    def enter_identifier(self, identifier, parent):
         pass
 
-    def exit_identifier(self, identifier):
+    def exit_identifier(self, identifier, parent):
         pass
 

--- a/stringfuzz/transformers/fuzz.py
+++ b/stringfuzz/transformers/fuzz.py
@@ -29,7 +29,7 @@ class LitTransformer(ASTWalker):
     def __init__(self, ast):
         super(LitTransformer, self).__init__(ast)
 
-    def exit_literal(self, literal):
+    def exit_literal(self, literal, parent):
         if isinstance(literal, IntLitNode):
             literal.value = random.randint(-literal.value, literal.value)
         elif isinstance(literal, StringLitNode):
@@ -49,7 +49,7 @@ class LitTransformer(ASTWalker):
                     pass
             literal.value = new_val
     
-    def exit_expression(self, expr):
+    def exit_expression(self, expr, parent):
         for type_list in REPLACEABLE_OPS:
             for i in range(len(expr.body)):
                 # Check if its a replaceable type, if so, randomly replace it

--- a/stringfuzz/transformers/graft.py
+++ b/stringfuzz/transformers/graft.py
@@ -18,7 +18,7 @@ class GraftTransformer(ASTWalker):
         super(GraftTransformer, self).__init__(ast)
         self.pairs = pairs
 
-    def enter_expression(self, expr):
+    def enter_expression(self, expr, parent):
         for i in range(len(expr.body)):
             for pair in self.pairs:
                 if expr.body[i] == pair[0]:
@@ -48,7 +48,7 @@ class GraftFinder(ASTWalker):
             pairs.append(self.rx)
         return pairs
 
-    def enter_literal(self, literal):
+    def enter_literal(self, literal, parent):
         replace = random.choice([True, False])
         if isinstance(literal, StringLitNode):
             if self.str[1]:
@@ -69,7 +69,7 @@ class GraftFinder(ASTWalker):
             else:
                 self.int[1] = literal
 
-    def enter_identifier(self, ident):
+    def enter_identifier(self, ident, parent):
         #TODO How to check type of identifiers?
         # if self.str[1]:
         #     if random.random() < 0.5:
@@ -78,7 +78,7 @@ class GraftFinder(ASTWalker):
         #     self.str[1] = ident
         pass
 
-    def enter_expression(self, expr):
+    def enter_expression(self, expr, parent):
         replace = random.choice([True, False])
         if isinstance(expr, StrToReNode):
             # take StrToReNode's to be literals for RX

--- a/stringfuzz/transformers/multiply.py
+++ b/stringfuzz/transformers/multiply.py
@@ -3,7 +3,7 @@ Multiplying every integer literal by n and repeating
 every character in a string literal n times for some n
 '''
 
-from stringfuzz.ast import StringLitNode, IntLitNode
+from stringfuzz.ast import StringLitNode, IntLitNode, ReRangeNode
 from stringfuzz.ast_walker import ASTWalker
 
 __all__ = [
@@ -11,12 +11,15 @@ __all__ = [
 ]
 
 class MultiplyTransformer(ASTWalker):
-    def __init__(self, ast, factor):
+    def __init__(self, ast, factor, re_range_flag):
         super(MultiplyTransformer, self).__init__(ast)
         self.factor = factor
+        self.re_range_flag = re_range_flag
 
-    def exit_literal(self, literal):
+    def exit_literal(self, literal, parent):
         if isinstance(literal, StringLitNode):
+            if isinstance(parent, ReRangeNode) and not self.re_range_flag:
+                return
             new_val = ""
             for char in literal.value:
                 new_val += char * self.factor
@@ -25,6 +28,6 @@ class MultiplyTransformer(ASTWalker):
             literal.value = literal.value * self.factor
 
 # public API
-def multiply(ast, factor):
-    transformed = MultiplyTransformer(ast, factor).walk()
+def multiply(ast, factor, re_range_flag):
+    transformed = MultiplyTransformer(ast, factor, re_range_flag).walk()
     return transformed

--- a/stringfuzz/transformers/reverse.py
+++ b/stringfuzz/transformers/reverse.py
@@ -13,11 +13,11 @@ class ReverseTransformer(ASTWalker):
     def __init__(self, ast):
         super(ReverseTransformer, self).__init__(ast)
 
-    def exit_literal(self, literal):
+    def exit_literal(self, literal, parent):
         if isinstance(literal, StringLitNode):
             literal.value = literal.value[::-1]
     
-    def exit_expression(self, expr):
+    def exit_expression(self, expr, parent):
         if isinstance(expr, (ConcatNode, ReConcatNode)):
             expr.body = reversed(expr.body)
 

--- a/stringfuzz/transformers/rotate.py
+++ b/stringfuzz/transformers/rotate.py
@@ -9,7 +9,7 @@ class RotateTransformer(ASTWalker):
     def __init__(self, ast):
         super(RotateTransformer, self).__init__(ast)
 
-    def exit_expression(self, expr):
+    def exit_expression(self, expr, parent):
         for uniform in [ALL_INT_ARGS, ALL_RX_ARGS, ALL_STR_ARGS]:
             # need at least two top level children
             uniform_expr = [isinstance(expr, C) for C in uniform]

--- a/stringfuzz/transformers/translate.py
+++ b/stringfuzz/transformers/translate.py
@@ -5,7 +5,7 @@ Permuting the alphabet in every string literal.
 import random
 import copy
 
-from stringfuzz.ast import StringLitNode
+from stringfuzz.ast import StringLitNode, ReRangeNode
 from stringfuzz.ast_walker import ASTWalker
 from stringfuzz import ALL_CHARS
 
@@ -17,9 +17,10 @@ WITH_INTEGERS    = list(ALL_CHARS)
 WITHOUT_INTEGERS = [c for c in ALL_CHARS if not c.isdecimal()]
 
 class TranslateTransformer(ASTWalker):
-    def __init__(self, ast, character_set):
+    def __init__(self, ast, character_set, re_range_flag):
         super(TranslateTransformer, self).__init__(ast)
         self.table = self.make_table(character_set)
+        self.re_range_flag = re_range_flag
 
     def make_table(self, character_set):
         shuffled = copy.copy(character_set)
@@ -28,15 +29,17 @@ class TranslateTransformer(ASTWalker):
         character_set = ''.join(character_set)
         return str.maketrans(character_set, shuffled)
 
-    def exit_literal(self, literal):
+    def exit_literal(self, literal, parent):
         if isinstance(literal, StringLitNode):
+            if isinstance(parent, ReRangeNode) and not self.re_range_flag:
+                return
             literal.value = literal.value.translate(self.table)
 
 # public API
-def translate(ast, integer_flag):
+def translate(ast, integer_flag, re_range_flag):
     if integer_flag:
         character_set = WITH_INTEGERS
     else:
         character_set = WITHOUT_INTEGERS
-    transformed = TranslateTransformer(ast, character_set).walk()
+    transformed = TranslateTransformer(ast, character_set, re_range_flag).walk()
     return transformed


### PR DESCRIPTION
Addressing issues #12 and #13.

- Added command line argument to specify if re.range string literals should be touched. 
- Modified walker to include information about parent
- Added check inside multiply and translate based on parent