### PR TITLE
adding merge transformer

### DIFF
--- a/bin/stringfuzzx
+++ b/bin/stringfuzzx
@@ -9,7 +9,7 @@ import argparse
 import random
 
 from stringfuzz.constants import LANGUAGES, SMT_20_STRING, SMT_25_STRING
-from stringfuzz.transformers import unprintable, nop, rotate, fuzz, graft, translate, reverse, multiply
+from stringfuzz.transformers import unprintable, nop, rotate, fuzz, graft, translate, reverse, multiply, merge
 from stringfuzz.generator import generate
 from stringfuzz.parser import parse, ParsingError
 from stringfuzz.ast import SettingNode, ExpressionNode, MetaExpressionNode
@@ -23,6 +23,7 @@ GRAFT       = 'graft'
 TRANSLATE   = 'translate'
 REVERSE     = 'reverse'
 MULTIPLY    = 'multiply'
+MERGE       = 'merge'
 
 TRANSFORMERS = {
     UNPRINTABLE: unprintable,
@@ -32,7 +33,8 @@ TRANSFORMERS = {
     GRAFT:       graft,
     TRANSLATE:   translate,
     REVERSE:     reverse,
-    MULTIPLY:    multiply
+    MULTIPLY:    multiply,
+    MERGE:       merge
 }
 
 # defaults
@@ -41,15 +43,19 @@ DEFAULT_RANDOM        = False
 DEFAULT_FACTOR        = 2
 DEFAULT_INTEGER_FLAG  = False
 DEFAULT_SKIP_RE_RANGE = True
+DEFAULT_RENAME_IDS    = False
 
 GET_MODEL = "get-model"
 GET_INFO  = "get-info"
+SET_LOGIC = "set-logic"
 TO_STRIP  = [GET_MODEL, GET_INFO]
 
 def should_keep(expr):
     if isinstance(expr, SettingNode):
         return False
     if isinstance(expr, MetaExpressionNode):
+        if expr.symbol == SET_LOGIC:
+            return True
         return False
     if isinstance(expr, ExpressionNode):
         if expr.symbol in TO_STRIP:
@@ -170,6 +176,34 @@ def main():
     # unprintable transformer
     unprintable_parser = subparsers.add_parser(UNPRINTABLE, help='unprintable transformer')
 
+    # merge transformer
+    merge_parser = subparsers.add_parser(MERGE, help='merge transformer')
+    merge_parser.add_argument(
+        '--file2',
+        '-f2',
+        required = True,
+        dest     = 'second_file',
+        metavar  = 'F',
+        type     = argparse.FileType('r'),
+        help     = 'second input file'
+    )
+    merge_parser.add_argument(
+        '--in-lang2',
+        '-i2',
+        dest    = 'second_input_language',
+        type    = str,
+        choices = LANGUAGES,
+        default = SMT_25_STRING,
+        help    = 'second input language (default: {})'.format(SMT_25_STRING)
+    )
+    merge_parser.add_argument(
+        '--rename',
+        dest    = 'rename_ids',
+        action  = 'store_true',
+        default = DEFAULT_RENAME_IDS,
+        help    = 'Rename identifiers to avoid conflicts (default: {})'.format(DEFAULT_RENAME_IDS)
+    )
+
     # parse args
     args = global_parser.parse_args()
 
@@ -188,8 +222,11 @@ def main():
     else:
         random.seed(args.seed)
 
+    # get args as a dict
+    transformer_args = vars(args)
+
     # read input
-    raw_in = args.input_file.read()
+    raw_in = input_file.read()
 
     # parse input
     try:
@@ -198,14 +235,28 @@ def main():
         print(e, file=sys.stderr)
         return 1
 
+    if transformer == merge:
+        # read second input
+        second_file = transformer_args['second_file']
+        second_input_language = transformer_args['second_input_language']
+        # pop arguments that shouldn't be passed on to the transformer
+        transformer_args.pop('second_file')
+        transformer_args.pop('second_input_language')
+
+        second_raw_in = second_file.read()
+
+        # parse second input
+        try:
+            second_ast = parse(second_raw_in, second_input_language)
+            transformer_args['second_ast'] = list(filter(should_keep, second_ast))
+        except ParsingError as e:
+            print(e, file=sys.stderr)
+            return 1
+
     # the nop transformer should not modify anything
     if transformer != nop:
-
         # filter out suppressed expressions
         ast = list(filter(should_keep, ast))
-
-    # get args as a dict
-    transformer_args = vars(args)
 
     # pop arguments that are specific to this script because
     # they shouldn't be passed on to the transformer

--- a/stringfuzz/ast.py
+++ b/stringfuzz/ast.py
@@ -41,7 +41,11 @@ __all__ = [
 
 # data structures
 class ASTNode(object):
-    pass
+    def __eq__(self, other):
+        return repr(self) == repr(other)
+
+    def __hash__(self):
+        return hash(repr(self))
 
 class LiteralNode(ASTNode):
     def __init__(self, value):

--- a/stringfuzz/transformers/__init__.py
+++ b/stringfuzz/transformers/__init__.py
@@ -6,3 +6,4 @@ from stringfuzz.transformers.graft import *
 from stringfuzz.transformers.translate import *
 from stringfuzz.transformers.reverse import *
 from stringfuzz.transformers.multiply import *
+from stringfuzz.transformers.merge import *

--- a/stringfuzz/transformers/merge.py
+++ b/stringfuzz/transformers/merge.py
@@ -1,0 +1,37 @@
+'''
+Combining two problems
+'''
+
+from stringfuzz.ast import ExpressionNode
+from stringfuzz.ast_walker import ASTWalker
+from stringfuzz.smt import smt_string_logic, smt_sat
+
+__all__ = [
+    'merge',
+]
+
+class RenameIDWalker(ASTWalker):
+    def __init__(self, ast, suffix):
+        super(RenameIDWalker, self).__init__(ast)
+        self.suffix = suffix
+
+    def exit_identifier(self, identifier, parent):
+        identifier.name += self.suffix
+
+def assertion(expr):
+    return isinstance(expr, ExpressionNode) and expr.symbol == "assert"
+
+def declaration(expr):
+    return isinstance(expr, ExpressionNode) and expr.symbol == "declare-fun"
+
+# public API
+def merge(first_ast, second_ast, rename_ids):
+    if rename_ids:
+        first_ast  = RenameIDWalker(first_ast, "1").walk()
+        second_ast = RenameIDWalker(second_ast, "2").walk()
+
+    combined     = set(first_ast + second_ast)
+    declarations = list(filter(declaration, combined))
+    assertions   = list(filter(assertion, combined))
+    transformed  = [smt_string_logic()] + declarations + assertions + [smt_sat()]
+    return transformed

--- a/stringfuzz/transformers/merge.py
+++ b/stringfuzz/transformers/merge.py
@@ -2,9 +2,11 @@
 Combining two problems
 '''
 
-from stringfuzz.ast import ExpressionNode
+from stringfuzz.ast import ExpressionNode, SortNode
 from stringfuzz.ast_walker import ASTWalker
 from stringfuzz.smt import smt_string_logic, smt_sat
+
+DECLARATIONS = ["declare-fun", "declare-const"]
 
 __all__ = [
     'merge',
@@ -22,7 +24,10 @@ def assertion(expr):
     return isinstance(expr, ExpressionNode) and expr.symbol == "assert"
 
 def declaration(expr):
-    return isinstance(expr, ExpressionNode) and expr.symbol == "declare-fun"
+    return isinstance(expr, ExpressionNode) and expr.symbol in DECLARATIONS
+
+def sort(expr):
+    return isinstance(expr, SortNode)
 
 # public API
 def merge(first_ast, second_ast, rename_ids):
@@ -32,6 +37,7 @@ def merge(first_ast, second_ast, rename_ids):
 
     combined     = set(first_ast + second_ast)
     declarations = list(filter(declaration, combined))
+    sorts        = list(filter(sort, combined))
     assertions   = list(filter(assertion, combined))
-    transformed  = [smt_string_logic()] + declarations + assertions + [smt_sat()]
+    transformed  = [smt_string_logic()] + declarations + sorts + assertions + [smt_sat()]
     return transformed


### PR DESCRIPTION
Example without renaming

```bash
stringfuzzg concats > 1.smt
stringfuzzg concats | stringfuzzx rotate | stringfuzzx merge -f2 1.smt
```
> (set-logic QF_S)
(declare-fun var4 () String)
(declare-fun var6 () String)
(declare-fun var2 () String)
(declare-fun var1 () String)
(declare-fun var0 () String)
(declare-fun var5 () String)
(declare-fun var3 () String)
(assert (= var0 (str.++ var6 (str.++ var5 (str.++ var4 (str.++ var3 (str.++ var2 var1)))))))
(assert (= var0 (str.++ var2 (str.++ (str.++ (str.++ (str.++ var1 var3) var4) var5) var6))))
(check-sat)

Example with renaming

```bash
stringfuzzg concats > 1.smt
stringfuzzg concats | stringfuzzx rotate | stringfuzzx merge -f2 1.smt --rename
```
>(set-logic QF_S)
(declare-fun var01 () String)
(declare-fun var21 () String)
(declare-fun var42 () String)
(declare-fun var31 () String)
(declare-fun var62 () String)
(declare-fun var52 () String)
(declare-fun var22 () String)
(declare-fun var41 () String)
(declare-fun var32 () String)
(declare-fun var12 () String)
(declare-fun var02 () String)
(declare-fun var61 () String)
(declare-fun var51 () String)
(declare-fun var11 () String)
(assert (= var01 (str.++ var21 (str.++ (str.++ (str.++ (str.++ var11 var31) var41) var51) var61))))
(assert (= var02 (str.++ var62 (str.++ var52 (str.++ var42 (str.++ var32 (str.++ var22 var12)))))))
(check-sat)